### PR TITLE
Removing a period at the end of a sentence

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -208,9 +208,10 @@ var/list/channel_to_radio_key = new
 	message = html_decode(message)
 
 	var/end_char = copytext_char(message, length(message), length(message) + 1)
+	/*
 	if(!(end_char in list(".", "?", "!", "-", "~", ":")))
 		message += "."
-
+	*/
 	return html_encode(message)
 
 /mob/living/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="", whispering)


### PR DESCRIPTION
## About the Pull Request
This query removes the period at the end of the sentence.


## Why It's Good For The Game

Because of encoding problems, the dot at the end of the sentence in Cyrillic is always put regardless of anything. This query removes this rule.

## Changelog

:cl:
code: Removing the function of adding a period at the end of a sentence
/:cl:
